### PR TITLE
S2: when expanding macros (like \R), assign expansion the same character offsets

### DIFF
--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -59,7 +59,7 @@ describe("The MathML builder", function() {
             expect(X.attr("s2:end")).toBe("10");
         });
 
-        it("from the '\\bm' style macro)", function() {
+        it("from the '\\bm' style macro", function() {
             const tex = "\\bm x";
             const mathMl = getMathMLObject(tex);
             const x = mathMl("mi:contains(x)");
@@ -67,12 +67,20 @@ describe("The MathML builder", function() {
             expect(x.attr("s2:end")).toBe("5");
         });
 
-        it("from the '\\rm' style macro)", function() {
+        it("from the '\\rm' style macro", function() {
             const tex = "\\rm x";
             const mathMl = getMathMLObject(tex);
             const x = mathMl("mi:contains(x)");
             expect(x.attr("s2:start")).toBe("0");
             expect(x.attr("s2:end")).toBe("5");
+        });
+
+        it("for the '\\R' macro", function() {
+            const tex = "\\R";
+            const mathMl = getMathMLObject(tex);
+            const x = mathMl("mi");
+            expect(x.attr("s2:start")).toBe("0");
+            expect(x.attr("s2:end")).toBe("2");
         });
     });
 

--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -75,6 +75,12 @@ describe("The MathML builder", function() {
             expect(x.attr("s2:end")).toBe("5");
         });
 
+        /*
+         * The following behavior should hold for all macros defined in 'macros.js',
+         * of which '\R' is just one case. The desired behavior is that
+         * the nodes created by expanding a macro are all assigned the character
+         * position of the macro and its arguments.
+         */
         it("for the '\\R' macro", function() {
             const tex = "\\R";
             const mathMl = getMathMLObject(tex);


### PR DESCRIPTION
There is a class of macros that KaTeX expands on its own, but when doing so, it overwrites the source location of the tokens parsed. For instance, the macro

```
\R
```

has the character offsets of [start: 0, end: 2] in the string above, but is parsed as having character offsets of [start: 0, end: 10]. This is because KaTeX expands it to the TeX `\mathbb{R}`, which consists of 10 characters.

This PR ensures that when a macro like `\R` is expanded, the tokens that it expands to are assigned the same character positions as the token it was expanded from (i.e., `\mathbb`, `{`, `R`, and `}` are all assigned the positions [start: 0, end: 2]). This ensures that when we find are trying to find the position of the characters that generated 'R' symbol in the original TeX in the ScholarPhi project, we are still able to do so.