### PR TITLE
S2: Fix offsets of elements generated from text macros (e.g., \textrm {text})

### DIFF
--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -162,6 +162,14 @@ describe("The MathML builder", function() {
             expect(msub.attr("s2:start")).toBe("0");
             expect(msub.attr("s2:end")).toBe("8");
         });
+
+        it("annotated with offsets including text subsymbols", function() {
+            const tex = "x_\\textrm{text}";
+            const mathMl = getMathMLObject(tex);
+            const msub = mathMl("msub");
+            expect(msub.attr("s2:start")).toBe("0");
+            expect(msub.attr("s2:end")).toBe("15");
+        });
     });
 
     describe("creates ticks", function() {


### PR DESCRIPTION
**What problem is this solving?** For a string of Roman-font text in a TeX equation, KaTeX was finding the wrong character positions.

The correct character positions for the text produced by

```tex
\textrm{hello}
```

are _start_ = 0, _end_ = 14---it should include the `\textrm` macro, because the formatting provides semantic meaning. KaTeX was only setting the location to the argument to the macro (i.e., either 'hello' or '{hello}', I cannot remember which).

This PR detects when text elements are getting created from `\textrm` macros, and sets the character positions of the text elements to include the span containing the `\textrm` token.