### PR TITLE
S2: support '\mathds' macro (for double-struck text)

### DIFF
--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -765,6 +765,10 @@ const fontMap: {[string]: {| variant: FontVariant, fontName: string |}} = {
         variant: "double-struck",
         fontName: "AMS-Regular",
     },
+    "mathds": {
+        variant: "double-struck",
+        fontName: "AMS-Regular",
+    },
     "mathcal": {
         variant: "script",
         fontName: "Caligraphic-Regular",

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -96,7 +96,7 @@ export const getVariant = function(
         return "bold-italic";
     } else if (font === "mathbf") {
         return "bold";
-    } else if (font === "mathbb") {
+    } else if (font === "mathbb" || font === "mathds") {
         return "double-struck";
     } else if (font === "mathfrak") {
         return "fraktur";

--- a/src/functions/font.js
+++ b/src/functions/font.js
@@ -57,7 +57,7 @@ defineFunction({
         "\\mathrm", "\\mathit", "\\mathbf", "\\mathnormal",
 
         // families
-        "\\mathbb", "\\mathcal", "\\mathfrak", "\\mathscr", "\\mathsf",
+        "\\mathbb", "\\mathds", "\\mathcal", "\\mathfrak", "\\mathscr", "\\mathsf",
         "\\mathtt",
 
         // aliases, except \bm defined below

--- a/src/katex.less
+++ b/src/katex.less
@@ -111,6 +111,7 @@
     }
 
     .mathbb,
+    .mathds,
     .textbb {
         font-family: KaTeX_AMS;
     }

--- a/src/wide-character.js
+++ b/src/wide-character.js
@@ -66,7 +66,7 @@ const wideLatinLetterData: Array<[string, string, string]> = [
 
 const wideNumeralData: Array<[string, string, string]> = [
     ["mathbf", "textbf", "Main-Bold"],                // 0-9 bold
-    ["", "", ""],                         // 0-9 double-struck. No KaTeX font.
+    ["mathds", "", "AMS-Regular"],                    // 0-9 double-struck
     ["mathsf", "textsf", "SansSerif-Regular"],        // 0-9 sans-serif
     ["mathboldsf", "textboldsf", "SansSerif-Bold"],   // 0-9 bold sans-serif
     ["mathtt", "texttt", "Typewriter-Regular"],       // 0-9 monospace

--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -23,6 +23,15 @@ describe("The MathML builder", function() {
         expect(mathMl("mi:contains(x)")).toHaveLength(1);
     });
 
+    describe("parses common macros", function() {
+        it("including \\mathds", function() {
+            const tex = "\\mathds{1}";
+            const mathMl = getMathMLObject(tex);
+            const one = mathMl("mn");
+            expect(one.attr("mathvariant")).toBe("double-struck");
+        });
+    });
+
     describe("creates identifiers", function() {
         it("annotated with index, start, and end", function() {
             const tex = "x";


### PR DESCRIPTION
Before, KaTeX was failing to parse the `\mathds` macro, making it hard for us to detect a symbol like `\mathds{R}`. `\mathds` makes text double-struck (e.g., turns "R" into "ℝ").

There is already another command for making text double-struck that _is_ recognized by KaTeX: `\mathbb`. Therefore, this PR consists of a change of finding every place that KaTeX processes `\mathbb` and making it process `\mathds` in the same way.