### PR TITLE
Separate out each letter; annotate letters with LaTeX font macros that apply to them

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -152,6 +152,18 @@ export const buildExpression = function(
     for (let i = 0; i < expression.length; i++) {
         const group = buildGroup(expression[i], options);
         if (group instanceof MathNode && lastGroup instanceof MathNode) {
+            /*
+            * S2: Disable the code below that merges consecutive letters together.
+            * By disabling this code, each letter remains in a node of its own.
+            * For instance, the number 1000 will consist of 4 'mn' nodes, one for
+            * each of the digits 1, 0, 0, and 0. The text 'hello' will consist of
+            * 5 'mtext' nodes, one for each letter 'h', 'e', 'l', 'l', and 'o'.
+            * Merging letters is disabled because this KaTeX code is used for the
+            * downstream task of detecting the character offsets of every single
+            * letter that makes up a larger symbol. Merging on letters into larger
+            * parent symbols is handled downstream outside of KaTeX.
+            */
+            /*
             // Concatenate adjacent <mtext>s
             if (group.type === 'mtext' && lastGroup.type === 'mtext'
                 && group.getAttribute('mathvariant') ===
@@ -194,6 +206,7 @@ export const buildExpression = function(
                     }
                 }
             }
+            */
         }
         groups.push(group);
         lastGroup = group;

--- a/src/functions/accent.js
+++ b/src/functions/accent.js
@@ -6,6 +6,7 @@ import utils from "../utils";
 import stretchy from "../stretchy";
 import {assertNodeType, checkNodeType} from "../parseNode";
 import {assertSpan, assertSymbolDomNode} from "../domTree";
+import {setFontAttribute} from "../s2-utils";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -190,6 +191,12 @@ const mathmlBuilder: MathMLBuilder<"accent"> = (group, options) => {
         group.isStretchy ?
             stretchy.mathMLnode(group.label) :
             new mathMLTree.MathNode("mo", [mml.makeText(group.label, group.mode)]);
+
+    /*
+     * S2: Annotate accent node with attribute declaring what LaTeX fonts have been
+     * applied to this accent.
+     */
+    setFontAttribute(accentNode, options);
 
     const node = new mathMLTree.MathNode(
         "mover",

--- a/src/functions/font.js
+++ b/src/functions/font.js
@@ -36,8 +36,8 @@ const mathmlBuilder = (group: ParseNode<"font">, options) => {
     ) {
         const adjustedStart = Math.min(Number(mmlGroupStart), fontLoc.start);
         const adjustedEnd = Math.max(Number(mmlGroupEnd), fontLoc.end);
-        mmlGroup.setAttribute("s2:start", String(adjustedStart));
-        mmlGroup.setAttribute("s2:end", String(adjustedEnd));
+        mmlGroup.setAttribute("s2:style-start", String(adjustedStart));
+        mmlGroup.setAttribute("s2:style-end", String(adjustedEnd));
     }
 
     return mmlGroup;

--- a/src/functions/symbolsOp.js
+++ b/src/functions/symbolsOp.js
@@ -2,6 +2,7 @@
 import {defineFunctionBuilders} from "../defineFunction";
 import buildCommon from "../buildCommon";
 import mathMLTree from "../mathMLTree";
+import {setFontAttribute} from "../s2-utils";
 
 import * as mml from "../buildMathML";
 
@@ -28,6 +29,12 @@ defineFunctionBuilders({
             // See delimsizing.js for stretchy delims.
             node.setAttribute("stretchy", "false");
         }
+        /*
+         * S2: Annotate node with attribute declaring what LaTeX fonts have been
+         * applied to this symbol.
+         */
+        setFontAttribute(node, options);
+
         return node;
     },
 });

--- a/src/functions/symbolsOrd.js
+++ b/src/functions/symbolsOrd.js
@@ -2,6 +2,7 @@
 import {defineFunctionBuilders} from "../defineFunction";
 import buildCommon from "../buildCommon";
 import mathMLTree from "../mathMLTree";
+import {setFontAttribute} from "../s2-utils";
 
 import * as mml from "../buildMathML";
 
@@ -30,6 +31,11 @@ defineFunctionBuilders({
         if (variant !== defaultVariant[node.type]) {
             node.setAttribute("mathvariant", variant);
         }
+        /*
+         * S2: Annotate node with attribute declaring what LaTeX fonts have been
+         * applied to this symbol.
+         */
+        setFontAttribute(node, options);
         return node;
     },
 });
@@ -58,6 +64,11 @@ defineFunctionBuilders({
         if (variant !== defaultVariant[node.type]) {
             node.setAttribute("mathvariant", variant);
         }
+        /*
+         * S2: Annotate node with attribute declaring what LaTeX fonts have been
+         * applied to this symbol.
+         */
+        setFontAttribute(node, options);
 
         return node;
     },

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -44,7 +44,7 @@ defineFunction({
         "\\textbf", "\\textmd",
         // Font Shapes
         "\\textit", "\\textup",
-        // S2: Aliases other commands that aren't equivalent, but should be
+        // S2: Aliases for other commands that aren't equivalent, but should be
         // parsed in a similar way
         "\\hbox", "\\mbox",
     ],

--- a/src/s2-utils.js
+++ b/src/s2-utils.js
@@ -1,0 +1,13 @@
+// @flow
+import type Options from "./Options";
+import type {MathNode} from "./mathMLTree";
+
+export const setFontAttribute = function(node: MathNode, options: Options): void {
+    const fontMacros = [
+        options.font,
+        options.fontFamily,
+        options.fontWeight,
+        options.fontShape,
+    ].filter(f => f !== "");
+    node.setAttribute("s2:font-macros", fontMacros.join("&"));
+};

--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -301,5 +301,12 @@ describe("The MathML builder", function() {
             expect(line.attr("s2:start")).toBe("0");
             expect(line.attr("s2:end")).toBe("10");
         });
+
+        it("annotated with style macros that formatted it", function() {
+            const tex = "\\mathbf{\\bar x}";
+            const mathMl = getMathMLObject(tex);
+            const bar = mathMl("mo");
+            expect(bar.attr("s2:font-macros")).toEqual("mathbf");
+        });
     });
 });

--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -42,37 +42,48 @@ describe("The MathML builder", function() {
             expect(x.attr("s2:end")).toBe("8");
         });
 
-        it("from style macros without braces", function() {
+        it("from style macros with braces", function() {
             const tex = "\\mathcal{X}";
             const mathMl = getMathMLObject(tex);
             const X = mathMl("mi:contains(X)");
             expect(X.attr("mathvariant")).toBe("script");
-            expect(X.attr("s2:start")).toBe("0");
+            expect(X.attr("s2:start")).toBe("8");
             expect(X.attr("s2:end")).toBe("11");
+            expect(X.attr("s2:style-start")).toBe("0");
+            expect(X.attr("s2:style-end")).toBe("11");
         });
 
-        it("from style macros with braces", function() {
+        it("from style macros without braces", function() {
             const tex = "\\mathcal X";
             const mathMl = getMathMLObject(tex);
             const X = mathMl("mi:contains(X)");
-            expect(X.attr("s2:start")).toBe("0");
+            expect(X.attr("s2:start")).toBe("9");
             expect(X.attr("s2:end")).toBe("10");
+            expect(X.attr("s2:style-start")).toBe("0");
+            expect(X.attr("s2:style-end")).toBe("10");
         });
 
         it("from the '\\bm' style macro)", function() {
             const tex = "\\bm x";
             const mathMl = getMathMLObject(tex);
             const x = mathMl("mi:contains(x)");
-            expect(x.attr("s2:start")).toBe("0");
-            expect(x.attr("s2:end")).toBe("5");
+            expect(x.attr("s2:style-start")).toBe("0");
+            expect(x.attr("s2:style-end")).toBe("5");
         });
 
         it("from the '\\rm' style macro)", function() {
             const tex = "\\rm x";
             const mathMl = getMathMLObject(tex);
             const x = mathMl("mi:contains(x)");
-            expect(x.attr("s2:start")).toBe("0");
-            expect(x.attr("s2:end")).toBe("5");
+            expect(x.attr("s2:style-start")).toBe("0");
+            expect(x.attr("s2:style-end")).toBe("5");
+        });
+
+        it("annotated with style macros that formatted it", function() {
+            const tex = "\\mathcal{X}";
+            const mathMl = getMathMLObject(tex);
+            const X = mathMl("mi");
+            expect(X.attr("s2:font-macros")).toEqual("mathcal");
         });
     });
 
@@ -125,8 +136,10 @@ describe("The MathML builder", function() {
              * style macro...
              */
             const msub = mathMl("msub");
-            expect(msub.attr("s2:start")).toBe("0");
+            expect(msub.attr("s2:start")).toBe("8");
             expect(msub.attr("s2:end")).toBe("13");
+            expect(msub.attr("s2:style-start")).toBe("0");
+            expect(msub.attr("s2:style-end")).toBe("13");
             /*
              * But the positions of the sub-symbols ('x' and 'i') should not. This
              * is because the positions are meant to serve as an index into the
@@ -150,13 +163,12 @@ describe("The MathML builder", function() {
         });
     });
 
-    describe("creates ticks", function() {
-        it("annotated with character offsets", function() {
-            const tex = "x'";
+    describe("creates operators", function() {
+        it("annotated with style macros that formatted it", function() {
+            const tex = "\\boldsymbol{+}";
             const mathMl = getMathMLObject(tex);
-            const tick = mathMl("mo:contains(')");
-            expect(tick.attr("s2:start")).toBe("1");
-            expect(tick.attr("s2:end")).toBe("2");
+            const plus = mathMl("mo");
+            expect(plus.attr("s2:font-macros")).toEqual("boldsymbol");
         });
     });
 
@@ -194,6 +206,13 @@ describe("The MathML builder", function() {
             expect(mathMl("mtext:contains(T)")).toHaveLength(1);
             expect(mathMl("mi:contains(x)")).toHaveLength(1);
         });
+
+        it("annotated with style macros that formatted it", function() {
+            const tex = "\\text{\\textbf{T}}";
+            const mathMl = getMathMLObject(tex);
+            const text = mathMl("mtext");
+            expect(text.attr("s2:font-macros")).toEqual("textbf");
+        });
     });
 
     describe("creates numbers", function() {
@@ -222,6 +241,23 @@ describe("The MathML builder", function() {
             expect(nums.eq(1).text()).toBe("2");
             expect(nums.eq(1).attr("s2:start")).toBe("1");
             expect(nums.eq(1).attr("s2:end")).toBe("2");
+        });
+
+        it("annotated with style macros that formatted it", function() {
+            const tex = "\\mathbf{1}";
+            const mathMl = getMathMLObject(tex);
+            const text = mathMl("mn");
+            expect(text.attr("s2:font-macros")).toEqual("mathbf");
+        });
+    });
+
+    describe("creates ticks", function() {
+        it("annotated with character offsets", function() {
+            const tex = "x'";
+            const mathMl = getMathMLObject(tex);
+            const tick = mathMl("mo:contains(')");
+            expect(tick.attr("s2:start")).toBe("1");
+            expect(tick.attr("s2:end")).toBe("2");
         });
     });
 

--- a/test/scholar-spec.js
+++ b/test/scholar-spec.js
@@ -162,34 +162,66 @@ describe("The MathML builder", function() {
 
     describe("creates text", function() {
         it("annotated with character offsets", function() {
-            const tex = "\\textrm{term}";
+            const tex = "\\textrm{T}";
             const mathMl = getMathMLObject(tex);
             const text = mathMl("mtext");
             expect(text.attr("s2:start")).toBe("8");
-            expect(text.attr("s2:end")).toBe("12");
+            expect(text.attr("s2:end")).toBe("9");
+        });
+
+        it("with each letter in its own node", function() {
+            const tex = "\\textrm{hi}";
+            const mathMl = getMathMLObject(tex);
+            const text = mathMl("mtext");
+            expect(text).toHaveLength(2);
+            expect(text.eq(0).text()).toBe("h");
+            expect(text.eq(0).attr("s2:start")).toBe("8");
+            expect(text.eq(0).attr("s2:end")).toBe("9");
+            expect(text.eq(1).text()).toBe("i");
+            expect(text.eq(1).attr("s2:start")).toBe("9");
+            expect(text.eq(1).attr("s2:end")).toBe("10");
         });
 
         it("from text in a '\\text' macro", function() {
-            const tex = "\\text{Text}";
+            const tex = "\\text{T}";
             const mathMl = getMathMLObject(tex);
-            expect(mathMl("mtext:contains(Text)")).toHaveLength(1);
+            expect(mathMl("mtext:contains(T)")).toHaveLength(1);
         });
 
         it("from '\\mbox's", function() {
-            const tex = "\\mbox{Text $x$}";
+            const tex = "\\mbox{T $x$}";
             const mathMl = getMathMLObject(tex);
-            expect(mathMl("mtext:contains(Text)")).toHaveLength(1);
+            expect(mathMl("mtext:contains(T)")).toHaveLength(1);
             expect(mathMl("mi:contains(x)")).toHaveLength(1);
         });
     });
 
     describe("creates numbers", function() {
         it("annotated with character offsets", function() {
-            const tex = "1000";
+            const tex = "1";
             const mathMl = getMathMLObject(tex);
             const num = mathMl("mn");
             expect(num.attr("s2:start")).toBe("0");
-            expect(num.attr("s2:end")).toBe("4");
+            expect(num.attr("s2:end")).toBe("1");
+        });
+
+        /*
+         * KaTeX has been modified to keep all letters and digits
+         * in separate nodes, so that offsets of every letter in
+         * the TeX can be recovered. This is required by our symbol
+         * extraction pipeline, which will attempt to extract the
+         * TeX for every single letter.
+         */
+        it("with each digit in a separate node", function() {
+            const tex = "42";
+            const mathMl = getMathMLObject(tex);
+            const nums = mathMl("mn");
+            expect(nums.eq(0).text()).toBe("4");
+            expect(nums.eq(0).attr("s2:start")).toBe("0");
+            expect(nums.eq(0).attr("s2:end")).toBe("1");
+            expect(nums.eq(1).text()).toBe("2");
+            expect(nums.eq(1).attr("s2:start")).toBe("1");
+            expect(nums.eq(1).attr("s2:end")).toBe("2");
         });
     });
 


### PR DESCRIPTION
As part of my effort to build out a faster symbol detector, I found that I wanted to know:

* What is every single letter that appears in each symbol?
* What LaTeX fonts is it rendered with?

This is important to know, because my faster symbol detector depends on rendering each of these letters on its own, in the style (e.g., bold, script, italic, etc.) that it is supposed to appear within the symbol.

This PR extends KaTeX to answer that question. There are two extensions:

1. Every multi-letter symbol and number is split into single letters.
2. Every letter is annotated with a `s2:font-macros` attribute which contains a `&`-delimited list of all fonts macro that were applied to that letter in LaTeX.

As a result, the equation:

```tex
\mathbf{200}
```

which was rendered before as:

```xml
<mn>200</mn>
```

is now rendered as:

```xml
<mrow>
  <mn s2:font-macros="mathbf">2</mn>
  <mn s2:font-macros="mathbf">0</mn>
  <mn s2:font-macros="mathbf">0</mn>
</mrow>
```

This allows us to render each letter separately with the font macros that applied to it as part of our faster symbol detection technique.

This will break the downstream paper processing code that depends on KaTeX, so there needs to be a companion commit in the https://github.com/allenai/scholarphi repository before this is merged into the master KaTeX branch.